### PR TITLE
Fix and improvements

### DIFF
--- a/src/iota/address.c
+++ b/src/iota/address.c
@@ -64,24 +64,11 @@ uint8_t address_generate(uint32_t *bip32_path, uint32_t bip32_path_length,
     cx_ecfp_public_key_t pub;
 
     uint8_t ret = 0;
-    BEGIN_TRY
-    {
-        TRY
-        {
-            ret =
-                ed25519_get_key_pair(bip32_path, bip32_path_length, &pk, &pub);
-        }
-        CATCH_OTHER(e)
-        {
-            THROW(e);
-        }
-        FINALLY
-        {
-            // always delete from stack
-            explicit_bzero(&pk, sizeof(pk));
-        }
-    }
-    END_TRY;
+
+    ret = ed25519_get_key_pair(bip32_path, bip32_path_length, &pk, &pub);
+
+    // always delete from stack
+    explicit_bzero(&pk, sizeof(pk));
 
     // ed25519_get_key_pair must succeed
     MUST(ret);

--- a/src/iota/constants.h
+++ b/src/iota/constants.h
@@ -34,10 +34,10 @@
 
 #define TOTAL_AMOUNT_MAX 2779530283277761ull
 
-#define INPUTS_MAX_COUNT 126
+#define INPUTS_MAX_COUNT 127
 #define INPUTS_MIN_COUNT 1
 
-#define OUTPUTS_MAX_COUNT 126
+#define OUTPUTS_MAX_COUNT 127
 #define OUTPUTS_MIN_COUNT 1
 
 #define DATA_BLOCK_SIZE 251 // cla + ins + p1 + p2 + p3 + data max 256 bytes

--- a/src/iota/ed25519.c
+++ b/src/iota/ed25519.c
@@ -27,24 +27,36 @@ uint8_t ed25519_get_key_pair(uint32_t *bip32_path, uint32_t bip32_path_length,
                              cx_ecfp_public_key_t *pub)
 {
     uint8_t keySeed[32];
+    uint8_t ret = 1;
 
     // getting the seed to derive and configuring it with SLIP10
     os_perso_derive_node_bip32_seed_key(
         HDW_ED25519_SLIP10, CX_CURVE_Ed25519, bip32_path, bip32_path_length,
         keySeed, NULL, (unsigned char *)"ed25519 seed", 12);
 
-    // initializing the private key and public key instance
-    // with selected curve ED25519
-    cx_ecfp_init_private_key(CX_CURVE_Ed25519, keySeed, sizeof(keySeed), pk);
-    cx_ecfp_init_public_key(CX_CURVE_Ed25519, NULL, 0, pub);
+    BEGIN_TRY
+    {
+        TRY
+        {
+            // initializing the private key and public key instance
+            // with selected curve ED25519
+            cx_ecfp_init_private_key(CX_CURVE_Ed25519, keySeed, sizeof(keySeed), pk);
+            cx_ecfp_init_public_key(CX_CURVE_Ed25519, NULL, 0, pub);
 
-    // generating the key pair
-    cx_ecfp_generate_pair(CX_CURVE_Ed25519, pub, pk, 1);
+            // generating the key pair
+            cx_ecfp_generate_pair(CX_CURVE_Ed25519, pub, pk, 1);
+        }
+        CATCH_ALL {
+            ret = 0;
+        }
+        FINALLY {
+            // resetting the variables to avoid leak
+            explicit_bzero(keySeed, sizeof(keySeed));
+        }
+    }
+    END_TRY;
 
-    // resetting the variables to avoid leak
-    explicit_bzero(keySeed, sizeof(keySeed));
-
-    return 1;
+    return ret;
 }
 
 // reversing the public key and changing the last byte
@@ -63,11 +75,27 @@ uint8_t ed25519_sign(cx_ecfp_private_key_t *privateKey, const uint8_t *msg,
                      uint32_t msg_length, unsigned char *output,
                      uint32_t *output_length)
 {
-    *output_length = cx_eddsa_sign(privateKey, 0, CX_SHA512, msg, msg_length,
-                                   NULL, 0, output, CX_SHA512_SIZE, NULL);
+    uint8_t ret = 1;
+
+    BEGIN_TRY
+    {
+        TRY
+        {
+            *output_length = cx_eddsa_sign(privateKey, 0, CX_SHA512, msg, msg_length,
+                                        NULL, 0, output, CX_SHA512_SIZE, NULL);
+        }
+        CATCH_ALL
+        {
+            ret = 0;
+        }
+        FINALLY {}
+    }
+    END_TRY;
+
 
     if (*output_length != SIGNATURE_SIZE_BYTES) {
-        return 0;
+        ret = 0;
     }
-    return 1;
+
+    return ret;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -74,7 +74,6 @@ static void IOTA_main()
                 if (rx == 0) {
                     CLOSE_TRY;
                     THROW(EXCEPTION_IO_RESET);
-                    break;
                 }
 
                 // check header validity

--- a/src/main.c
+++ b/src/main.c
@@ -92,7 +92,7 @@ static void IOTA_main()
             }
             CATCH(EXCEPTION_IO_RESET)
             {
-                CLOSE_TRY;
+                THROW(EXCEPTION_IO_RESET);
                 break;
             }
             CATCH_OTHER(e)
@@ -111,7 +111,6 @@ static void IOTA_main()
                 case SW_DEVICE_IS_LOCKED:
                 case SW_CLA_NOT_SUPPORTED:
                     // do not reset anything
-                    CLOSE_TRY;
                     break;
                 default:
                     // reset states and UI
@@ -255,13 +254,11 @@ __attribute__((section(".boot"))) int main(void)
             CATCH(EXCEPTION_IO_RESET)
             {
                 // reset IO and UX
-                CLOSE_TRY;
                 continue;
             }
             CATCH_ALL
             {
                 // exit on all other exceptions
-                CLOSE_TRY;
                 break;
             }
             FINALLY

--- a/src/main.c
+++ b/src/main.c
@@ -72,7 +72,6 @@ static void IOTA_main()
 
                 // when no APDU received, trigger a reset
                 if (rx == 0) {
-                    CLOSE_TRY;
                     THROW(EXCEPTION_IO_RESET);
                 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -72,6 +72,7 @@ static void IOTA_main()
 
                 // when no APDU received, trigger a reset
                 if (rx == 0) {
+                    CLOSE_TRY;
                     break;
                 }
 
@@ -91,6 +92,7 @@ static void IOTA_main()
             }
             CATCH(EXCEPTION_IO_RESET)
             {
+                CLOSE_TRY;
                 break;
             }
             CATCH_OTHER(e)
@@ -109,6 +111,7 @@ static void IOTA_main()
                 case SW_DEVICE_IS_LOCKED:
                 case SW_CLA_NOT_SUPPORTED:
                     // do not reset anything
+                    CLOSE_TRY;
                     break;
                 default:
                     // reset states and UI
@@ -252,11 +255,13 @@ __attribute__((section(".boot"))) int main(void)
             CATCH(EXCEPTION_IO_RESET)
             {
                 // reset IO and UX
+                CLOSE_TRY;
                 continue;
             }
             CATCH_ALL
             {
                 // exit on all other exceptions
+                CLOSE_TRY;
                 break;
             }
             FINALLY

--- a/src/main.c
+++ b/src/main.c
@@ -93,7 +93,6 @@ static void IOTA_main()
             CATCH(EXCEPTION_IO_RESET)
             {
                 THROW(EXCEPTION_IO_RESET);
-                break;
             }
             CATCH_OTHER(e)
             {

--- a/src/main.c
+++ b/src/main.c
@@ -73,6 +73,7 @@ static void IOTA_main()
                 // when no APDU received, trigger a reset
                 if (rx == 0) {
                     CLOSE_TRY;
+                    THROW(EXCEPTION_IO_RESET);
                     break;
                 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -72,7 +72,7 @@ static void IOTA_main()
 
                 // when no APDU received, trigger a reset
                 if (rx == 0) {
-                    THROW(EXCEPTION_IO_RESET);
+                    break;
                 }
 
                 // check header validity
@@ -91,7 +91,7 @@ static void IOTA_main()
             }
             CATCH(EXCEPTION_IO_RESET)
             {
-                THROW(EXCEPTION_IO_RESET);
+                break;
             }
             CATCH_OTHER(e)
             {


### PR DESCRIPTION
 - Corrections according to the documentation regarding syntactic validation (https://wiki.iota.org/tips/tips/TIP-0007/#syntactic-validation).
 - Replace `memcmp_bytewise` for `memcmp`
 - Improve exception handling (previously secrets were not being wiped from memory) 