### PR TITLE
Migrate CodeQL workflow to reusable workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,32 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  CodeQL-Build:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      actions: read
-      packages: read
-    container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-legacy:latest
-
-    steps:
-      - name: Install git
-        run: apt-get update && apt-get install -y git
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: cpp
-          config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Build app
-        run: make clean && BOLOS_SDK=/opt/nanos-secure-sdk make
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+  analyse:
+    name: Call Ledger CodeQL analysis
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_codeql_checks.yml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates the CodeQL workflow to use the centralized reusable workflow from `LedgerHQ/ledger-app-workflows`.