### PR TITLE
Migrate to reusable workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,42 +1,16 @@
-name: "CodeQL"
+name: CodeQL
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "develop"
+      - main
+      - master
+      - develop
   pull_request:
-    branches:
-      - "develop"
-  schedule:
-    - cron: '0 0 * * *'
 
 jobs:
-  CodeQL-Build:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      actions: read
-      packages: read
-    container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-legacy:latest
-
-    steps:
-      - name: Install git
-        run: apt-get update && apt-get install -y git
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
-        with:
-          languages: cpp
-          config-file: ./.github/codeql/codeql-config.yml
-
-      - name: Build app
-        run: make clean && BOLOS_SDK=/opt/nanos-secure-sdk make
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+  analyse:
+    name: Call Ledger CodeQL analysis
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_codeql_checks.yml@v1
+    secrets: inherit

--- a/.github/workflows/ragger-tests.yml
+++ b/.github/workflows/ragger-tests.yml
@@ -1,0 +1,16 @@
+name: Ragger Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  ragger_tests:
+    name: Ragger Tests
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_ragger_tests.yml@v1
+    secrets: inherit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,16 @@
+name: Unit Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_unit_tests.yml@v1
+    secrets: inherit


### PR DESCRIPTION
This PR migrates workflows to use centralized reusable workflows from `LedgerHQ/ledger-app-workflows`.